### PR TITLE
adjusted the penalty to include multi-key per IP

### DIFF
--- a/hip/validator/forward.py
+++ b/hip/validator/forward.py
@@ -122,7 +122,11 @@ async def forward(self):
         # You are encouraged to define your own deserialization function.
         deserialize=True,
     )
-
+    
+    for uid, response in zip(miner_uids, responses): # for each miner response
+        ip = response.axon.ip # get the ip of the miner
+        self.ip_miner_map[ip].add(uid) # add the miner to the set of miners for this ip
+    
     is_correct_answer = get_rewards(
         self, ground_truth=ground_truth, responses=responses
     )


### PR DESCRIPTION
Added some code to update the ip_miner_map each time we receive responses from miners.

With the apply_ip_adjustment function the penalty increases significantly for the first few additional keys. After that the marginal penalty for each additional key diminishes, preventing overly extreme score reductions for IPs with heaps of keys.